### PR TITLE
Bump oead dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorama~=0.4.3
 numpy~=1.19.2
-oead~=1.1.4
+oead~=1.2.0


### PR DESCRIPTION
Several other tools require or default to the latest version of oead (currently 1.2.0), which can cause dependency errors when trying to use `botw_havok`'s current requirement. The only changes between 1.2.x and 1.1.x pertain to the AAMP API, so there should be no side-effects from upgrading.